### PR TITLE
adding abcd data conversion script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,12 @@
 */old/
 */phenotype/
 ABIDE_I/Phenotypic_V1_0b.csv
+ABCD/data/
 HBN/Data Dictionaries/
 UKB/Data_Dictionary_Showcase.tsv
 UKB/PHESANT-1.1/
 NKI/assessments_documentation/
+HCP/unrestricted_arshitha_1_20_2023_13_54_41.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -24,6 +26,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+.idea/
 .Python
 build/
 develop-eggs/

--- a/ABCD/.gitignore
+++ b/ABCD/.gitignore
@@ -1,4 +1,0 @@
-data/
-test_output/
-test.py
-data_convert.ipynb

--- a/ABCD/.gitignore
+++ b/ABCD/.gitignore
@@ -1,0 +1,4 @@
+data/
+test_output/
+test.py
+data_convert.ipynb

--- a/ABCD/README.md
+++ b/ABCD/README.md
@@ -36,6 +36,15 @@ From the [ABCD Study's "About" webpage](https://abcdstudy.org/about/):
 
 1. Note: Many print statements will pop up, but these have all been reviewed manually and addressed programmatically, as necessary, in parts of the `dictionary.py` script.
 
+## Steps to convert this study's data files from TXT to TSV format files
+
+1. Download ABCD Release 4.0 Tabulated data package through the [NIMH Data Archive's (NDA) ABCD Study page](https://nda.nih.gov/general-query.html?q=query=featured-datasets:Adolescent%20Brain%20Cognitive%20Development%20Study%20(ABCD)).
+2. Place the downloaded data in a new subdirectory called `data/` within the `ABCD/` subdirectory of this repository.
+3. Run `data_convert.py` from the `ABCD/` directory to convert the data files in `.txt` format to BIDS recommended `.tsv` format. 
+    ```bash
+    python data_convert.py
+    ```
+
 ## Notes about these data dictionaries
 
 1. Though `DataType` is not a BIDS-valid field in the sidecar JSON, it has been included for reference.

--- a/ABCD/data_convert.py
+++ b/ABCD/data_convert.py
@@ -42,8 +42,8 @@ def main():
     data_dicts = list(data_dict_dir.glob('*.csv'))
     data_files_no_dict = []
     dict_no_data_files = []
-    for dict in data_dicts:
-        dict_prefix = dict.name.split('.')[0]
+    for data_dict in data_dicts:
+        dict_prefix = data_dict.stem
         expected_data_file = tab_data_dir.joinpath(dict_prefix + '.csv')
         if expected_data_file not in data_files:
             dict_no_data_files.append(expected_data_file.name)

--- a/ABCD/data_convert.py
+++ b/ABCD/data_convert.py
@@ -56,12 +56,12 @@ def main():
 
         # creating a list of lists where each sub-list is a formatted row
         rows = []
-        curr_f = open(tab_data_dir.joinpath(d + '.txt'), 'r')
-        for idx, line in enumerate(curr_f.readlines()):
-            if idx != 1:  # skip over row describing fields
-                line = ','.join(line.strip('\n').split('\t'))
-                new_line = [word.strip('\"') for word in line.split(',') if not word == ""]
-                rows.append(new_line)
+        with open(tab_data_dir.joinpath(d + '.txt'), 'r') as curr_f:
+            for idx, line in enumerate(curr_f.readlines()):
+                if idx != 1:  # skip over row describing fields
+                    no_newline = line.rstrip('\n')
+                    new_line = [word.lstrip('"').rstrip('"') for word in no_newline.split('\t') if not word == ""]
+                    rows.append(new_line)
         # writing the list of lists as a TSV file
         with open(outdir.joinpath(d + '.tsv'), 'w') as new_f:
             wr = csv.writer(new_f, delimiter='\t', quoting=csv.QUOTE_MINIMAL)

--- a/ABCD/data_convert.py
+++ b/ABCD/data_convert.py
@@ -37,7 +37,7 @@ def main():
 
     # extract nda short names into a list
     data_files = list(tab_data_dir.glob('*.txt'))
-    data_short_names = [i.name.split('.txt')[0] for i in
+    data_short_names = [i.stem for i in
                         data_files]  # assert that this is indeed a list of strings.
     data_dicts = list(data_dict_dir.glob('*.csv'))
     data_files_no_dict = []

--- a/ABCD/data_convert.py
+++ b/ABCD/data_convert.py
@@ -60,8 +60,10 @@ def main():
             for idx, line in enumerate(curr_f.readlines()):
                 if idx != 1:  # skip over row describing fields
                     no_newline = line.rstrip('\n')
-                    new_line = [word.lstrip('"').rstrip('"') for word in no_newline.split('\t') if not word == ""]
+                    new_line = [word.lstrip('"').rstrip('"') if not word == "" else "n/a" for word in
+                                no_newline.split('\t')]
                     rows.append(new_line)
+
         # writing the list of lists as a TSV file
         with open(outdir.joinpath(d + '.tsv'), 'w') as new_f:
             wr = csv.writer(new_f, delimiter='\t', quoting=csv.QUOTE_MINIMAL)

--- a/ABCD/data_convert.py
+++ b/ABCD/data_convert.py
@@ -16,9 +16,14 @@ def help_text():
     return args
 
 
-def data_summary(data_with_no_dict):
-    print(f"A total of {len(data_with_no_dict)} data files don't have a corresponding data dictionary.")
+def data_summary(data_with_no_dict, dict_no_data_files):
+    print(
+        f"A total of {len(data_with_no_dict)} data files in the ABCD Release 4.0 tabular data package don't have a corresponding data dictionary.")
     print(data_with_no_dict)
+
+    print(
+        f"A total of {len(dict_no_data_files)} data dictionaries don't have a corresponding data file in the ABCD release 4.0 tabular data package.")
+    print(dict_no_data_files)
 
 
 def main():
@@ -31,10 +36,17 @@ def main():
     outdir = Path('phenotype')
 
     # extract nda short names into a list
+    data_files = list(tab_data_dir.glob('*.txt'))
     data_short_names = [i.name.split('.txt')[0] for i in
-                        tab_data_dir.glob('*.txt')]  # assert that this is indeed a list of strings.
+                        data_files]  # assert that this is indeed a list of strings.
     data_dicts = list(data_dict_dir.glob('*.csv'))
     data_files_no_dict = []
+    dict_no_data_files = []
+    for dict in data_dicts:
+        dict_prefix = dict.name.split('.')[0]
+        expected_data_file = tab_data_dir.joinpath(dict_prefix + '.csv')
+        if expected_data_file not in data_files:
+            dict_no_data_files.append(expected_data_file.name)
 
     for d in data_short_names:
         expected_dict = data_dict_dir.joinpath(d + '.csv')  # constructing dictionary filename
@@ -54,7 +66,7 @@ def main():
         with open(outdir.joinpath(d + '.tsv'), 'w') as new_f:
             wr = csv.writer(new_f, delimiter='\t', quoting=csv.QUOTE_MINIMAL)
             wr.writerows(rows)
-    data_summary(data_files_no_dict)
+    data_summary(data_files_no_dict, dict_no_data_files)
 
 
 if __name__ == '__main__':

--- a/ABCD/data_convert.py
+++ b/ABCD/data_convert.py
@@ -1,0 +1,65 @@
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+
+def get_args():
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter, description=__doc__)
+    parser.add_argument('-t', '--tabular-data', type=Path, action='store', dest='tab_data', metavar='TAB_DATA_DIR',
+                        help='Path to directory with tabular data files in \'.txt\' format.')
+    parser.add_argument('-d', '--dictionaries', type=Path, action='store', dest='dicts', metavar='DICTS_DIR',
+                        default=Path('.'), help="Path to directory with data dictionaries in \'.csv\' format.")
+    parser.add_argument('-o', '--output-dir', type=Path, action='store', dest='outdir', metavar='OUTPUT_DIR',
+                        default=Path('.'), help="Destination directory for the \'.tsv\' formatted files.")
+    args = parser.parse_args()
+
+    return args.tab_data.resolve(), args.dicts.resolve(), args.outdir.resolve()
+
+
+def data_summary(data_with_no_dict):
+    print(f"A total of {len(data_with_no_dict)} data files don't have a corresponding data dictionary.")
+    print(data_with_no_dict)
+
+
+def main():
+    # get command line arguments
+    tab_data_dir, data_dict_dir, outdir = get_args()
+
+    # extract nda short names into a list
+    data_short_names = [i.name.split('.txt')[0] for i in
+                        tab_data_dir.glob('*.txt')]  # assert that this is indeed a list of strings.
+    data_dicts = list(data_dict_dir.glob('*.csv'))
+    data_files_no_dict = []
+
+    for d in data_short_names:
+        expected_dict = data_dict_dir.joinpath(d + '.csv')  # constructing dictionary filename
+        if expected_dict not in data_dicts:
+            data_files_no_dict.append(d + '.txt')  # constructing data filename
+        else:
+            types_dict = {}  # dict of fields and data types
+            dict_df = pd.read_csv(expected_dict)
+            tsv_fields = dict_df['ElementName'].to_list()
+
+            # type casting fields once it's read into a dataframe
+            for col in tsv_fields:
+                datatype = dict_df.loc[dict_df['ElementName'] == col, 'DataType'].values
+                if datatype and datatype[0] == 'Integer':
+                    types_dict[col] = 'Int64'
+                elif datatype and datatype[0] == 'String':
+                    types_dict[col] = 'str'
+
+            data_df = pd.read_csv(tab_data_dir.joinpath(d + '.txt'), sep='\t', dtype=types_dict, skiprows=[1])
+            # # print(types_dict)
+            bids_data_df = data_df[tsv_fields]
+            print(bids_data_df.head())
+            # display(bids_data_df)
+            # bids_data_df.to_csv(f"../dataset-phenotypes/ABCD/phenotype/{d + '.tsv'}", sep='\t',
+            #                     quoting=csv.QUOTE_MINIMAL,
+            #                     index=False)
+
+    data_summary(data_files_no_dict)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
@ericearl I'm back to solving #12 for the ABCD dataset. I downloaded the release 4.0 shared data package (only tabular data) from NDA. I've tested the conversion from `.txt` files to `.tsv` files and the script itself is working fine except for one problem. 

When the data are read into a pandas data frame, the columns with any missing values is converted to float type irrespective of whether it's string or integer type. I'm currently writing a function that type casts columns based on data type mentioned in the dictionary. I've a couple of questions about formatting of the final TSV though: 
1. The values in .txt files as downloaded from NDA are all enclosed in double quotes and therefore, all values are of the string type. Would it be better for the values in final TSV file to be encoded with `quoting=csv.QUOTE_ALL` ? 
2. Or, would it be more user-friendly for a column, let's say of type integer, to remain as integers in the final TSV? If we want to do this, then we'd also have to encode missing values with an integer value. (e.g., -999) 

Thoughts?